### PR TITLE
Add support for Python 3.6 and cleanups

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = src
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ bin
 develop-eggs
 parts
 eggs/
+.coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,23 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - pypy
-  - pypy3
-install:
-  - pip install tox-travis
+  - 3.6
+  - pypy-5.4.1
 script:
-  - tox
+  - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+
+after_success:
+  - coveralls
 notifications:
-    email: false
+  email: false
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install -U -e ".[test]"
+
+
+cache: pip
+
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.1.0 (unreleased)
 ------------------
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
 - Drop support for Python 3.2 and 2.6.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .coveragerc
+include .travis.yml
 
 recursive-include src *
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,11 @@ def alltests():
     suites = list(zope.testrunner.find.find_suites(options))
     return unittest.TestSuite(suites)
 
+tests_require = [
+    'zope.testing',
+    'zope.testrunner',
+]
+
 setup(
     name='zope.applicationcontrol',
     version='4.1.0.dev0',
@@ -50,8 +55,8 @@ setup(
         read('CHANGES.rst')
         ),
     license='ZPL 2.1',
-    keywords = "zope ztk application control",
-    classifiers = [
+    keywords="zope ztk application control",
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
@@ -63,16 +68,19 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
-        'Framework :: Zope3'],
-    url='http://cheeseshop.python.org/pypi/zope.applicationcontrol',
-    extras_require=dict(
-        test=['zope.testing']),
-    package_dir = {'': 'src'},
+        'Framework :: Zope3',
+    ],
+    url='http://github.com/zopefoundation/zope.applicationcontrol',
+    extras_require={
+        'test': tests_require,
+    },
+    package_dir={'': 'src'},
     packages=find_packages('src'),
     namespace_packages=['zope'],
     install_requires=[
@@ -83,11 +91,8 @@ setup(
           'zope.security',
           'zope.traversing>=3.7.0',
         ],
-    tests_require = [
-        'zope.testing',
-        'zope.testrunner',
-        ],
-    test_suite = '__main__.alltests',
-    include_package_data = True,
-    zip_safe = False,
-    )
+    tests_require=tests_require,
+    test_suite='__main__.alltests',
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,7 +1,1 @@
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/applicationcontrol/runtimeinfo.py
+++ b/src/zope/applicationcontrol/runtimeinfo.py
@@ -109,7 +109,7 @@ class RuntimeInfo(object):
             except UnicodeError:
                 continue
             info.append(t)
-        return u''.join(info)
+        return u' '.join(info)
 
     def getCommandLine(self):
         """See zope.app.applicationcontrol.interfaces.IRuntimeInfo"""

--- a/src/zope/applicationcontrol/tests/test_applicationcontrol.py
+++ b/src/zope/applicationcontrol/tests/test_applicationcontrol.py
@@ -33,14 +33,13 @@ class Test(unittest.TestCase):
     def test_startTime(self):
         assert_time = time.time()
         test_time = self._Test__new().getStartTime()
-
-        self.assertTrue(abs(assert_time - test_time) < time_tolerance)
+        self.assertAlmostEqual(assert_time, test_time, delta=time_tolerance)
 
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite(Test),
-        ))
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
+    ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/zope/applicationcontrol/tests/test_runtimeinfo.py
+++ b/src/zope/applicationcontrol/tests/test_runtimeinfo.py
@@ -116,10 +116,14 @@ class Test(unittest.TestCase):
         try:
             platform.uname = bad_uname
             plat = runtime_info.getSystemPlatform()
+            self.assertEqual(plat, u'')
+
+            platform.uname = lambda: ('a', 'b')
+            plat = runtime_info.getSystemPlatform()
+            self.assertEqual(plat, u'a b')
         finally:
             platform.uname = uname
 
-        self.assertEqual(plat, u'')
 
     def test_CommandLine(self):
         runtime_info = self._Test__new()

--- a/src/zope/applicationcontrol/tests/test_runtimeinfo.py
+++ b/src/zope/applicationcontrol/tests/test_runtimeinfo.py
@@ -13,11 +13,13 @@
 """Runtime Info Tests
 """
 import unittest
-import os, sys, time
+import os
+import sys
+import time
 
 try:
     import locale
-except ImportError:
+except ImportError: # pragma: no cover
     locale = None
 
 from zope import component
@@ -30,11 +32,10 @@ from zope.applicationcontrol.interfaces import IRuntimeInfo, IZopeVersion
 time_tolerance = 2
 stupid_version_string = "3085t0klvn93850voids"
 
-PY3 = sys.version_info[0] == 3
-if PY3:
-    _u = str
-else:
-    _u = unicode
+try:
+    text_type = unicode
+except NameError:
+    text_type = str
 
 
 @implementer(IZopeVersion)
@@ -54,7 +55,7 @@ class Test(unittest.TestCase):
     def _getPreferredEncoding(self):
         try:
             result = locale.getpreferredencoding()
-        except (locale.Error, AttributeError):
+        except (locale.Error, AttributeError): # pragma: no cover
             result = ''
         # Under some systems, getpreferredencoding() can return ''
         # (e.g., Python 2.7/MacOSX/LANG=en_us.UTF-8). This then blows
@@ -63,9 +64,7 @@ class Test(unittest.TestCase):
 
     def _getFileSystemEncoding(self):
         enc = sys.getfilesystemencoding()
-        if enc is None:
-            enc = self._getPreferredEncoding()
-        return enc
+        return enc or self._getPreferredEncoding()
 
     def testIRuntimeInfoVerify(self):
         verifyObject(IRuntimeInfo, self._Test__new())
@@ -84,7 +83,7 @@ class Test(unittest.TestCase):
         runtime_info = self._Test__new()
 
         # we expect that there is no utility
-        self.assertEqual(runtime_info.getZopeVersion(), _u("Unavailable"))
+        self.assertEqual(runtime_info.getZopeVersion(), u"Unavailable")
 
         siteManager = component.getSiteManager()
         siteManager.registerUtility(TestZopeVersion(), IZopeVersion)
@@ -96,11 +95,31 @@ class Test(unittest.TestCase):
         enc = self._getPreferredEncoding()
         self.assertEqual(
             runtime_info.getPythonVersion(),
-            sys.version if PY3 else sys.version.decode(enc))
+            sys.version if not isinstance(sys.version, bytes)
+            else sys.version.decode(enc))
 
     def test_SystemPlatform(self):
         runtime_info = self._Test__new()
-        self.assertTrue(runtime_info.getSystemPlatform())
+        plat = runtime_info.getSystemPlatform()
+        self.assertTrue(plat)
+        self.assertIsInstance(plat, text_type)
+
+        # Now something that can't be decoded
+        import platform
+        uname = platform.uname
+
+        def bad_uname():
+            class BadObject(object):
+                def decode(self, _enc):
+                    raise UnicodeError("Not gonna happen")
+            return (BadObject(),)
+        try:
+            platform.uname = bad_uname
+            plat = runtime_info.getSystemPlatform()
+        finally:
+            platform.uname = uname
+
+        self.assertEqual(plat, u'')
 
     def test_CommandLine(self):
         runtime_info = self._Test__new()
@@ -119,14 +138,56 @@ class Test(unittest.TestCase):
 
         # get the uptime the current implementation calculates
         test_uptime = runtime_info.getUptime()
+        self.assertAlmostEqual(asserted_uptime, test_uptime, delta=time_tolerance)
 
-        self.assertTrue(abs(asserted_uptime - test_uptime) < time_tolerance)
+    @unittest.skipIf(not sys.path, "Need entries on path")
+    def test_getPythonPath_returns_unicode(self):
+        runtime_info = self._Test__new()
+        path = runtime_info.getPythonPath()
+        for p in path:
+            self.assertIsInstance(p, text_type)
 
+    def test_getDeveloperMode(self):
+        from zope.applicationcontrol import runtimeinfo as module
+        orig_appsetup = module.appsetup
+
+        runtime_info = self._Test__new()
+
+        try:
+            # Module not available
+            module.appsetup = None
+            self.assertEqual(runtime_info.getDeveloperMode(), 'undefined')
+
+            # context not available
+            class Setup(object):
+                context = None
+                @classmethod
+                def getConfigContext(cls):
+                    return cls.context
+
+            module.appsetup = Setup
+            self.assertEqual(runtime_info.getDeveloperMode(), 'undefined')
+
+            features = []
+            class Context(object):
+                @staticmethod
+                def hasFeature(name):
+                    return name in features
+
+            # Feature off
+            Setup.context = Context
+            self.assertEqual(runtime_info.getDeveloperMode(), 'Off')
+
+            # Feature on
+            features.append('devmode')
+            self.assertEqual(runtime_info.getDeveloperMode(), 'On')
+        finally:
+            module.appsetup = orig_appsetup
 
 def test_suite():
     return unittest.TestSuite((
-        unittest.makeSuite(Test),
-        ))
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
+    ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,9 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3
+    py27, pypy, py33, py34, py35, py36
 
 [testenv]
 commands =
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
-# (and it seems I can't use zope.dottedname[testing] here, so forget DRY)
+    zope-testrunner --test-path=src []
 deps =
-    zope.interface
-    zope.component
-    zope.location
-    zope.security
-    zope.traversing
-    zope.testing
-    zope.testrunner
+    .[test]


### PR DESCRIPTION
- 100% code coverage
- Remove last vestiges of Python 3.2 support in the form of _u()
- Check for object type instead of Python version when deciding when
  to encode. It's not impossible for sys.path to have unicode entries
  on Python 2, or bytes entries on Python 3.