### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.1 (2025-02-13)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-5.2 (unreleased)
+6.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ tests_require = [
 
 setup(
     name='zope.applicationcontrol',
-    version='5.2.dev0',
+    version='6.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description='Zope applicationcontrol',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@
 ##############################################################################
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -29,7 +28,7 @@ def read(*rnames):
 
 tests_require = [
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 setup(
@@ -68,9 +67,6 @@ setup(
     extras_require={
         'test': tests_require,
     },
-    package_dir={'': 'src'},
-    packages=find_packages('src'),
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     install_requires=[
         'setuptools',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
